### PR TITLE
Replace sw-precache with webpack offline plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "deploy-s3": "node scripts/deploy-to-s3.js"
   },
   "dependencies": {
-    "preact": "^8.1.0"
+    "preact": "^8.1.0",
+    "offline-plugin": "^4.7.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.6",
@@ -32,7 +33,6 @@
     "s3": "^4.4.0",
     "sass-loader": "^4.1.1",
     "style-loader": "^0.13.1",
-    "sw-precache-webpack-plugin": "^0.8.0",
     "webpack": "^2.2.0",
     "webpack-dev-server": "^2.2.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -11,29 +11,17 @@ const renderRoot = function() {
 renderRoot();
 
 if (process.env.NODE_ENV === "production") {
-  if ("serviceWorker" in navigator && location.protocol === "https:") {
-    navigator.serviceWorker
-      .register("service-worker.js")
-      .then(function(reg) {
-        reg.onupdatefound = function() {
-          const installingWorker = reg.installing;
-
-          installingWorker.onstatechange = function() {
-            switch (installingWorker.state) {
-              case "installed":
-                if (navigator.serviceWorker.controller) {
-                  const event = new Event("app:update");
-                  document.dispatchEvent(event);
-                }
-                break;
-            }
-          };
-        };
-      })
-      .catch(function(e) {
-        console.error("Error during service worker registration:", e);
-      });
-  }
+  const offlineRuntime = require("offline-plugin/runtime");
+  offlineRuntime.install({
+    onUpdateReady() {
+      // update immediately
+      offlineRuntime.applyUpdate();
+    },
+    onUpdated: () => {
+      const event = new Event("app:update");
+      document.dispatchEvent(event);
+    }
+  });
 } else {
   require("preact/devtools");
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ const exclude = /(node_modules|bower_components)/;
 //** webpack plugins **//
 
 const webpack = require('webpack');
-const SWPrecache = require('sw-precache-webpack-plugin');
+const OfflinePlugin = require('offline-plugin');
 const Clean = require('clean-webpack-plugin');
 const Copy = require('copy-webpack-plugin');
 const HTML = require('html-webpack-plugin');
@@ -50,12 +50,18 @@ if (isProd) {
     plugins.push(
         new webpack.LoaderOptionsPlugin({minimize: true, debug: false}),
         new webpack.optimize.UglifyJsPlugin(uglify),
-        new SWPrecache({
-            filename: 'service-worker.js',
-            navigateFallback: 'index.html',
-            navigateFallbackWhitelist: [/^([^.]+)$/], // urls without extension
-            staticFileGlobsIgnorePatterns: [/\.map$/],
-            minify: true
+        new OfflinePlugin({
+          autoUpdate: true,
+          relativePaths: true,
+          rewrites: { "/": "/index.html" },
+          ServiceWorker: {
+            output: 'service-worker.js',
+            navigateFallback: "index.html",
+            events: true
+          },
+          AppCache: {
+            events: true
+          }
         })
     );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1576,7 +1576,7 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-extend@~0.4.0:
+deep-extend@^0.4.0, deep-extend@~0.4.0:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.1.tgz#efe4113d08085f4e6f9687759810f807469e2253"
 
@@ -1702,6 +1702,10 @@ ecc-jsbn@~0.1.1:
 ee-first@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
+
+ejs@^2.3.4:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
 electron-to-chromium@^1.2.3:
   version "1.2.4"
@@ -2679,7 +2683,7 @@ loader-runner@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.2.0.tgz#824c1b699c4e7a2b6501b85902d5b862bf45b3fa"
 
-loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5:
+loader-utils@0.2.x, loader-utils@^0.2.11, loader-utils@^0.2.15, loader-utils@^0.2.16, loader-utils@^0.2.7, loader-utils@~0.2.2, loader-utils@~0.2.5:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.16.tgz#f08632066ed8282835dff88dfb52704765adee6d"
   dependencies:
@@ -2876,7 +2880,7 @@ minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
 
-"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@~3.0.2:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.2, minimatch@^3.0.3, minimatch@~3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.3.tgz#2a4e4090b96b2db06a9d7df01055a62a77c9b774"
   dependencies:
@@ -3100,6 +3104,16 @@ object.omit@^2.0.0:
 obuf@^1.0.0, obuf@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/obuf/-/obuf-1.1.1.tgz#104124b6c602c6796881a042541d36db43a5264e"
+
+offline-plugin@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/offline-plugin/-/offline-plugin-4.7.0.tgz#4c2fca6cd46c6dd7f29fc94ade21e5f82a62c4df"
+  dependencies:
+    deep-extend "^0.4.0"
+    ejs "^2.3.4"
+    loader-utils "0.2.x"
+    minimatch "^3.0.3"
+    slash "^1.0.0"
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Offline plugin supports both service workers and appcache
(required for iOS, because it doesnt support service workers yet).

Closes #1.